### PR TITLE
Phase inversion switch

### DIFF
--- a/include/private/plugins/gate.h
+++ b/include/private/plugins/gate.h
@@ -170,6 +170,7 @@ namespace lsp
                     plug::IPort            *pHold;              // Hold time
                     plug::IPort            *pReduction;         // Reduction
                     plug::IPort            *pMakeup;            // Makeup
+                    plug::IPort            *pPhase;             // Phase invert
 
                     plug::IPort            *pDryGain;           // Dry gain
                     plug::IPort            *pWetGain;           // Wet gain

--- a/res/doc/configs/gate_lr.cfg
+++ b/res/doc/configs/gate_lr.cfg
@@ -149,6 +149,9 @@ gr_l = -24.40 db
 # Makeup gain Left [G]: 0.00100000..1000.00000000
 mk_l = 0.00 db
 
+# Phase invert Left [boolean]: true/false
+ph_l = false
+
 # Dry gain Left [G]: 0.00000000..10.00000000
 cdr_l = -inf db
 
@@ -190,6 +193,9 @@ gr_r = -109.19 db
 
 # Makeup gain Right [G]: 0.00100000..1000.00000000
 mk_r = 0.00 db
+
+# Phase invert Right [boolean]: true/false
+ph_r = false
 
 # Dry gain Right [G]: 0.00000000..10.00000000
 cdr_r = -inf db

--- a/res/doc/configs/gate_mono.cfg
+++ b/res/doc/configs/gate_mono.cfg
@@ -96,6 +96,9 @@ gr = -123.58 db
 # Makeup gain [G]: 0.00100000..1000.00000000
 mk = -24.71 db
 
+# Phase invert [boolean]: true/false
+ph = false
+
 # Dry gain [G]: 0.00000000..10.00000000
 cdr = -inf db
 

--- a/res/doc/configs/gate_ms.cfg
+++ b/res/doc/configs/gate_ms.cfg
@@ -152,6 +152,9 @@ gr_m = -55.26 db
 # Makeup gain Mid [G]: 0.00100000..1000.00000000
 mk_m = 0.00 db
 
+# Phase invert Mid [boolean]: true/false
+ph_m = false
+
 # Dry gain Mid [G]: 0.00000000..10.00000000
 cdr_m = -inf db
 
@@ -193,6 +196,9 @@ gr_s = -162.86 db
 
 # Makeup gain Side [G]: 0.00100000..1000.00000000
 mk_s = 0.00 db
+
+# Phase invert Side [boolean]: true/false
+ph_s = false
 
 # Dry gain Side [G]: 0.00000000..10.00000000
 cdr_s = -101.43 db

--- a/res/doc/configs/gate_stereo.cfg
+++ b/res/doc/configs/gate_stereo.cfg
@@ -103,6 +103,9 @@ gr = -80.63 db
 # Makeup gain [G]: 0.00100000..1000.00000000
 mk = 0.00 db
 
+# Phase invert [boolean]: true/false
+ph = false
+
 # Dry gain [G]: 0.00000000..10.00000000
 cdr = -inf db
 

--- a/res/doc/configs/sc_gate_lr.cfg
+++ b/res/doc/configs/sc_gate_lr.cfg
@@ -159,6 +159,9 @@ gr_l = -24.40 db
 # Makeup gain Left [G]: 0.00100000..1000.00000000
 mk_l = 0.00 db
 
+# Phase invert Left [boolean]: true/false
+ph_l = false
+
 # Dry gain Left [G]: 0.00000000..10.00000000
 cdr_l = -inf db
 
@@ -200,6 +203,9 @@ gr_r = -72.00 db
 
 # Makeup gain Right [G]: 0.00100000..1000.00000000
 mk_r = 0.00 db
+
+# Phase invert Right [boolean]: true/false
+ph_r = false
 
 # Dry gain Right [G]: 0.00000000..10.00000000
 cdr_r = -inf db

--- a/res/doc/configs/sc_gate_mono.cfg
+++ b/res/doc/configs/sc_gate_mono.cfg
@@ -101,6 +101,9 @@ gr = -72.00 db
 # Makeup gain [G]: 0.00100000..1000.00000000
 mk = 0.00 db
 
+# Phase invert [boolean]: true/false
+ph = false
+
 # Dry gain [G]: 0.00000000..10.00000000
 cdr = -inf db
 

--- a/res/doc/configs/sc_gate_ms.cfg
+++ b/res/doc/configs/sc_gate_ms.cfg
@@ -162,6 +162,9 @@ gr_m = -55.26 db
 # Makeup gain Mid [G]: 0.00100000..1000.00000000
 mk_m = 0.00 db
 
+# Phase invert Mid [boolean]: true/false
+ph_m = false
+
 # Dry gain Mid [G]: 0.00000000..10.00000000
 cdr_m = -inf db
 
@@ -203,6 +206,9 @@ gr_s = -72.00 db
 
 # Makeup gain Side [G]: 0.00100000..1000.00000000
 mk_s = 0.00 db
+
+# Phase invert Side [boolean]: true/false
+ph_s = false
 
 # Dry gain Side [G]: 0.00000000..10.00000000
 cdr_s = -101.43 db

--- a/res/doc/configs/sc_gate_stereo.cfg
+++ b/res/doc/configs/sc_gate_stereo.cfg
@@ -108,6 +108,9 @@ gr = -72.00 db
 # Makeup gain [G]: 0.00100000..1000.00000000
 mk = 0.00 db
 
+# Phase invert [boolean]: true/false
+ph = false
+
 # Dry gain [G]: 0.00000000..10.00000000
 cdr = -inf db
 

--- a/res/main/ui/plugins/dynamics/gate/single.xml
+++ b/res/main/ui/plugins/dynamics/gate/single.xml
@@ -433,7 +433,8 @@
 								<knob id="mk" scolor="kscale"/>
 								<value id="gr" sline="true" width="48"/>
 								<value id="mk" sline="true" width="48"/>
-								<cell cols="2"><button id="gh" height="22" hfill="true" pad.h="6" text="labels.hysteresis" ui:inject="Button_cyan"/></cell>
+								<button id="gh" width="48" height="22" pad.h="6" text="labels.hysteresis" ui:inject="Button_cyan"/>
+								<button id="ph" width="48" height="22" pad.h="6" text="labels.chan.phase" ui:inject="Button_yellow"/>
 							</grid>
 						</cell>
 
@@ -504,7 +505,8 @@
 								<knob id="mk_${xa}" scolor="${clr_a}"/>
 								<value id="gr_${xa}" sline="true" width="48"/>
 								<value id="mk_${xa}" sline="true" width="48"/>
-								<cell cols="2"><button id="gh_${xa}" height="22" hfill="true" pad.h="6" text="labels.hysteresis" ui:inject="Button_${clr_a}"/></cell>
+								<button id="gh_${xa}" height="22" pad.h="6" text="labels.hysteresis" ui:inject="Button_${clr_a}"/>
+								<button id="ph_${xa}" height="22" pad.h="6" text="labels.chan.phase" ui:inject="Button_yellow"/>
 							</grid>
 						</cell>
 
@@ -553,7 +555,8 @@
 								<knob id="mk_${xb}" scolor="${clr_b}"/>
 								<value id="gr_${xb}" sline="true" width="48"/>
 								<value id="mk_${xb}" sline="true" width="48"/>
-								<cell cols="2"><button id="gh_${xb}" height="22" hfill="true" pad.h="6" text="labels.hysteresis" ui:inject="Button_${clr_b}"/></cell>
+								<button id="gh_${xb}" height="22" pad.h="6" text="labels.hysteresis" ui:inject="Button_${clr_b}"/>
+								<button id="ph_${xb}" height="22" pad.h="6" text="labels.chan.phase" ui:inject="Button_yellow"/>
 							</grid>
 						</cell>
 

--- a/src/doc/manuals/plugins/gate.php
+++ b/src/doc/manuals/plugins/gate.php
@@ -21,7 +21,8 @@
 		else
 			echo " is";
 	?>provided. Additional <b>Hysteresis</b> curve is available to provide accurate control of the fading of the signal.
-	Also additional	dry/wet control allows to mix processed and unprocessed signal together. 
+	Also additional	dry/wet control allows to mix processed and unprocessed signal together.
+	When <b>Phase</b> inversion is enabled, it allows to create "ducking" effect.
 </p>
 <?php if ($m == 's') { ?>
 <p>Additionally, <b>Stereo split mode</b> allows to apply processing to the left and right channels independently while
@@ -57,6 +58,7 @@ keeping the same settings for the left and right channels.</p>
 <ul>
 	<li><b>Reduction</b> - the amount of gain applied to the input signal when the gate is closed (if negative) or open (if positive).</li>
 	<li><b>Makeup</b> - additional amplification gain after processing stage.</li>
+	<li><b>Phase</b> - invert the phase.</li>
 	<li><b>Attack</b> - attack time of the gate.</li>
 	<li><b>Release</b> - release time of the gate.</li>
 	<li><b>Curve</b> - Basic gate curve characteristics:</li>

--- a/src/main/meta/gate.cpp
+++ b/src/main/meta/gate.cpp
@@ -172,6 +172,7 @@ namespace lsp
             CONTROL("hold" id, "Hold time" label, "Hold time" alias, U_MSEC, gate_metadata::HOLD_TIME), \
             LOG_CONTROL("gr" id, "Reduction" label, "Reduction" alias, U_GAIN_AMP, gate_metadata::REDUCTION), \
             LOG_CONTROL("mk" id, "Makeup gain" label, "Makeup" alias, U_GAIN_AMP, gate_metadata::MAKEUP), \
+            SWITCH("ph" id, "Phase invert" label, "Phase" alias, 0.0f), \
             AMP_GAIN10("cdr" id, "Dry gain" label, "Dry" alias, GAIN_AMP_M_INF_DB),     \
             AMP_GAIN10("cwt" id, "Wet gain" label, "Wet" alias, GAIN_AMP_0_DB), \
             PERCENTS("cdw" id, "Dry/Wet balance" label, "Dry/Wet" alias, 100.0f, 0.1f), \

--- a/src/main/plug/gate.cpp
+++ b/src/main/plug/gate.cpp
@@ -246,6 +246,7 @@ namespace lsp
                 c->pRelease         = NULL;
                 c->pReduction       = NULL;
                 c->pMakeup          = NULL;
+                c->pPhase           = NULL;
 
                 c->pDryGain         = NULL;
                 c->pWetGain         = NULL;
@@ -376,6 +377,7 @@ namespace lsp
                     c->pHold            = sc->pHold;
                     c->pReduction       = sc->pReduction;
                     c->pMakeup          = sc->pMakeup;
+                    c->pPhase           = sc->pPhase;
 
                     c->pDryGain         = sc->pDryGain;
                     c->pWetGain         = sc->pWetGain;
@@ -396,6 +398,7 @@ namespace lsp
                     BIND_PORT(c->pHold);
                     BIND_PORT(c->pReduction);
                     BIND_PORT(c->pMakeup);
+                    BIND_PORT(c->pPhase);
 
                     BIND_PORT(c->pDryGain);
                     BIND_PORT(c->pWetGain);
@@ -724,6 +727,10 @@ namespace lsp
 
                 c->fDryGain         = (dry_gain * drywet + 1.0f - drywet) * out_gain;
                 c->fWetGain         = wet_gain * drywet * out_gain;
+
+                // Invert phase
+                const bool phase    = c->pPhase->value() >= 0.5f;
+                c->fWetGain   = phase ? -c->fWetGain : c->fWetGain;
 
                 if (c->fMakeup != makeup)
                 {
@@ -1339,6 +1346,7 @@ namespace lsp
                     v->write("pHold", c->pHold);
                     v->write("pReduction", c->pReduction);
                     v->write("pMakeup", c->pMakeup);
+                    v->write("pPhase", c->pPhase);
 
                     v->write("pDryGain", c->pDryGain);
                     v->write("pWetGain", c->pWetGain);


### PR DESCRIPTION
This PR introduces phase inversion switch, allowing gate to work in "ducking" mode. Just like in ReaGate and Pro-G. It is useful for reducing level of the main channel (e.g. music) when there is a signal on the side channel (e.g. voice). User need to set Dry to 0 dB, Dry/Wet to 100% and Wet to some negative value (e.g. -3 dB). Phase inversion definitely makes sense in SC Mono and SC Stereo modes. I believe it also makes sense in Mono and Stereo in music production, but I am not a musician. I really don't know about LR and MS modes.

The inversion is implemented by multiplying `c->fWetGain` by -1 in `update_settings()`. Let me know if there is a more preferred way.

I didn't find a place for the new switch in UI better than under Makeup control. Maybe you have a better idea - that's why I haven't updated screenshots yet.